### PR TITLE
Update JuMP to 1.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "OptimalBids"
 uuid = "54ed2464-0158-49e7-9a8e-1c1697a616e3"
 authors = ["Andrew Rosemberg"]
-version = "1.3.1"
+version = "1.3.2"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
@@ -10,8 +10,8 @@ PowerModels = "c36e90e8-916a-50a6-bd94-075b64ef4655"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 
 [compat]
-ChainRulesCore = "~1.13"
-JuMP = "^0.22"
+ChainRulesCore = "~1.14"
+JuMP = "~1"
 PowerModels = "~0.19"
 Reexport = "~1.2"
 julia = "^1.6"


### PR DESCRIPTION
Update JuMP to 1.0.

This will require either for `NonconvexCore.jl` to update it's compatibility or `OptimalBids.jl` removing `Nonconvex` interface from tests.